### PR TITLE
Add clippy config, fix things it finds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,21 @@ crate-type = ["cdylib", "rlib"]
 [dev-dependencies]
 anymap = "0.12.1"
 serde_json = "1.0"
+
+
+[lints.rust]
+# This codebase should never need to use any unsafe code. We're not accessing
+# registers, messing with raw pointers, or any of that old man C stuff.
+# However, we are doing C ABI stuff, and some of those things are unsafe
+# (most notably, the use of no_mangle).
+unsafe_code = "deny"
+
+[lints.clippy]
+## NB - see clippy.toml for more granular configurations.
+
+# Runtime unwraps are disallowed because they can panic.
+unwrap_used = "deny"
+
+# Expect is effectively unwrap with a nice error message, so it follows the
+# same rationale as above as above.
+expect_used = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+
+# For both unrwap and expect, we don't want them to be generally used.
+# However:
+# 1. If it panics at build, we can fix it at build time.
+# 2. We play a little looser with tests. We can skip some error handling and
+#    just allow it to panic and fail the test.
+allow-unwrap-in-consts = true
+allow-unwrap-in-tests = true
+allow-expect-in-consts = true
+allow-expect-in-tests = true

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -5,6 +5,12 @@ pub trait FileSystem {
 #[derive(Clone)]
 pub struct RealFileSystem {}
 
+impl Default for RealFileSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RealFileSystem {
     pub fn new() -> Self {
         Self {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[allow(unsafe_code)]
 #[unsafe(no_mangle)]
 pub extern "C" fn downloader_init() -> i32 {
     0

--- a/tests/fakes/macros.rs
+++ b/tests/fakes/macros.rs
@@ -45,11 +45,11 @@ impl AnyMapExt for ::anymap::AnyMap {
 #[macro_export]
 macro_rules! fs {
     ($($json:tt)+) => {
-        crate::fakes::fake_filesystem::fs_from_json(serde_json::json!($($json)+))
+        $crate::fakes::fake_filesystem::fs_from_json(serde_json::json!($($json)+))
     };
 
     () => {
-        crate::fakes::fake_filesystem::empty_fs()
+        $crate::fakes::fake_filesystem::empty_fs()
     };
 }
 


### PR DESCRIPTION
[rust-clippy](https://github.com/rust-lang/rust-clippy) is a super linter for rust which is highly configurable. (Think of it as a super `cargo check`.) You can run it with `cargo clippy`.

This establishes a basic config which disallows the use of `unsafe`[1], `unwrap`, and `expect`, except as explicitly allowed via an `#[allow(...)]` macro.

[1] This is actually accomplished by the base linter.

**NOTE:** You must have clippy installed via `rustup component add clippy` for `cargo clippy` commands to work.